### PR TITLE
fix: replace IsValidLowLevel() with IsValid() across 6 files (issue #3)

### DIFF
--- a/Plugins/ActorPools/Source/NexusActorPools/Private/NActorPoolsDeveloperOverlay.cpp
+++ b/Plugins/ActorPools/Source/NexusActorPools/Private/NActorPoolsDeveloperOverlay.cpp
@@ -115,7 +115,7 @@ void UNActorPoolsDeveloperOverlay::Unbind(const UWorld* World)
 	}
 	
 	
-	if (ActorPoolList != nullptr && ActorPoolList->IsValidLowLevel())
+	if (IsValid(ActorPoolList))
 	{
 		TArray<UObject*> Items = ActorPoolList->GetListItems();
 		const int32 ItemCount = Items.Num();
@@ -150,7 +150,7 @@ void UNActorPoolsDeveloperOverlay::OnWorldBeginTearDown(UWorld* World)
 
 void UNActorPoolsDeveloperOverlay::UpdateBanner() const
 {
-	if (ActorPoolList != nullptr && ActorPoolList->IsValidLowLevel() && ActorPoolList->GetNumItems() > 0)
+	if (IsValid(ActorPoolList) && ActorPoolList->GetNumItems() > 0)
 	{
 		HideContainerBanner();
 	}

--- a/Plugins/DynamicRefs/Source/NexusDynamicRefs/Private/NDynamicRefsDeveloperOverlay.cpp
+++ b/Plugins/DynamicRefs/Source/NexusDynamicRefs/Private/NDynamicRefsDeveloperOverlay.cpp
@@ -164,11 +164,9 @@ void UNDynamicRefsDeveloperOverlay::OnWorldBeginTearDown(UWorld* World)
 
 void UNDynamicRefsDeveloperOverlay::UpdateBanner() const
 {
-	const bool bNamedReferences = (NamedReferences != nullptr && 
-		NamedReferences->IsValidLowLevel() && 
+	const bool bNamedReferences = (IsValid(NamedReferences) &&
 		NamedReferences->GetNumItems() > 0);
-	const bool bDynamicReferences = (DynamicReferences != nullptr && 
-		DynamicReferences->IsValidLowLevel() && 
+	const bool bDynamicReferences = (IsValid(DynamicReferences) &&
 		DynamicReferences->GetNumItems() > 0);
 		
 	if (bNamedReferences || bDynamicReferences)

--- a/Plugins/ProcGen/Source/NexusProcGen/Private/NProcGenDeveloperOverlay.cpp
+++ b/Plugins/ProcGen/Source/NexusProcGen/Private/NProcGenDeveloperOverlay.cpp
@@ -28,7 +28,7 @@ void UNProcGenDeveloperOverlay::NativeConstruct()
 
 void UNProcGenDeveloperOverlay::NativeDestruct()
 {
-	if (OperationsList != nullptr && OperationsList->IsValidLowLevel())
+	if (IsValid(OperationsList))
 	{
 		OperationsList->ClearListItems();
 	}
@@ -68,7 +68,7 @@ void UNProcGenDeveloperOverlay::OnOperationStatusChanged(UNProcGenOperation* Ope
 
 void UNProcGenDeveloperOverlay::UpdateBanner() const
 {
-	if (OperationsList != nullptr && OperationsList->IsValidLowLevel() && OperationsList->GetNumItems() > 0)
+	if (IsValid(OperationsList) && OperationsList->GetNumItems() > 0)
 	{
 		HideContainerBanner();
 	}

--- a/Plugins/ProcGen/Source/NexusProcGen/Private/NProcGenOperationListViewEntry.cpp
+++ b/Plugins/ProcGen/Source/NexusProcGen/Private/NProcGenOperationListViewEntry.cpp
@@ -6,7 +6,7 @@
 
 void UNProcGenOperationListViewEntry::NativeDestruct()
 {
-	if (Operation != nullptr && Operation->IsValidLowLevel())
+	if (IsValid(Operation))
 	{
 		Operation->OnDisplayMessageChanged.RemoveDynamic(this, &UNProcGenOperationListViewEntry::OnOperationDisplayMessageChanged);\
 		Operation->OnTasksChanged.RemoveDynamic(this, &UNProcGenOperationListViewEntry::OnOperationTasksChanged);

--- a/Plugins/UI/Source/NexusUI/Private/Widgets/NDeveloperOverlay.cpp
+++ b/Plugins/UI/Source/NexusUI/Private/Widgets/NDeveloperOverlay.cpp
@@ -5,7 +5,7 @@
 
 void UNDeveloperOverlay::ShowContainerBanner(const FText& Text, ENColor MessageColor, ENColor BannerColor) const
 {
-	if (ContainerBanner != nullptr && ContainerBanner->IsValidLowLevel())
+	if (IsValid(ContainerBanner))
 	{
 		ContainerBanner->SetVisibility(ESlateVisibility::SelfHitTestInvisible);
 		ContainerBanner->SetBrushColor(FNColor::GetLinearColor(BannerColor));

--- a/Plugins/UI/Source/NexusUI/Public/Widgets/NButtonListViewEntry.h
+++ b/Plugins/UI/Source/NexusUI/Public/Widgets/NButtonListViewEntry.h
@@ -96,7 +96,7 @@ protected:
 
 	virtual void NativeDestruct() override
 	{
-		if (Button != nullptr && Button->IsValidLowLevel())
+		if (IsValid(Button))
 		{
 			Button->OnClicked.RemoveAll(this);
 			Button->OnHovered.RemoveAll(this);


### PR DESCRIPTION
## Summary

- `IsValidLowLevel()` is not the correct UObject validity check in Unreal Engine — it bypasses the GC pending-kill flag and does not handle objects being destroyed mid-frame, which can cause silent corruption or crashes during GC sweeps
- The correct replacement is `IsValid(ptr)`, which checks for `nullptr`, pending-kill, and GC-marked states in one call
- `IsValid()` also subsumes the redundant `ptr != nullptr &&` prefix that preceded every `IsValidLowLevel()` call, making each site shorter and cleaner
- No logic changes beyond the correctness fix

## Occurrences fixed (9 total across 6 files)

| File | Sites | Pattern replaced |
|---|---|---|
| `NActorPoolsDeveloperOverlay.cpp` | 2 | `ptr != nullptr && ptr->IsValidLowLevel()` |
| `NDynamicRefsDeveloperOverlay.cpp` | 2 | `ptr != nullptr && ptr->IsValidLowLevel()` |
| `NProcGenDeveloperOverlay.cpp` | 2 | `ptr != nullptr && ptr->IsValidLowLevel()` |
| `NProcGenOperationListViewEntry.cpp` | 1 | `ptr != nullptr && ptr->IsValidLowLevel()` |
| `NDeveloperOverlay.cpp` | 1 | `ptr != nullptr && ptr->IsValidLowLevel()` |
| `NButtonListViewEntry.h` | 1 | `ptr != nullptr && ptr->IsValidLowLevel()` |

## Test plan

- [ ] Build succeeds with no new warnings or errors
- [ ] Developer overlays (ActorPools, DynamicRefs, ProcGen) open and dismiss cleanly in PIE
- [ ] NButtonListViewEntry widgets bind and unbind delegates without error in PIE
- [ ] ProcGenOperationListViewEntry releases delegates cleanly when destroyed mid-operation

https://claude.ai/code/session_01UTQiq6YhBwMAToBjX4cJhA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTQiq6YhBwMAToBjX4cJhA)_