### PR TITLE
Deduplicate GEngine world-iteration loop in DeveloperOverlay subclasses

### DIFF
--- a/Plugins/ActorPools/Source/NexusActorPools/Private/NActorPoolsDeveloperOverlay.cpp
+++ b/Plugins/ActorPools/Source/NexusActorPools/Private/NActorPoolsDeveloperOverlay.cpp
@@ -24,13 +24,8 @@ void UNActorPoolsDeveloperOverlay::NativeConstruct()
 	AddWorldDelegateHandle = FWorldDelegates::OnPostWorldInitialization.AddUObject(this, &UNActorPoolsDeveloperOverlay::OnWorldPostInitialization);
 	RemoveWorldDelegateHandle = FWorldDelegates::OnWorldBeginTearDown.AddUObject(this, &UNActorPoolsDeveloperOverlay::OnWorldBeginTearDown);
 	
-	// Look at all worlds and add them to bindings
-	const TIndirectArray<FWorldContext>& WorldContexts = GEngine->GetWorldContexts();
-	for (const auto& Context : WorldContexts)
-	{
-		Bind(Context.World());
-	}
-	
+	BindAllCurrentWorlds();
+
 	UpdateTimer = NEXUS::ActorPools::ConsoleCommands::DeveloperOverlayUpdateRate;
 
 	UpdateBanner();
@@ -43,11 +38,7 @@ void UNActorPoolsDeveloperOverlay::NativeDestruct()
 	FWorldDelegates::OnPostWorldInitialization.Remove(AddWorldDelegateHandle);
 	FWorldDelegates::OnWorldBeginTearDown.Remove(RemoveWorldDelegateHandle);
 	
-	const TIndirectArray<FWorldContext>& WorldContexts = GEngine->GetWorldContexts();
-	for (const auto& Context : WorldContexts)
-	{
-		Unbind(Context.World());
-	}
+	UnbindAllCurrentWorlds();
 
 	ActorPoolList->ClearListItems();
 	Super::NativeDestruct();

--- a/Plugins/ActorPools/Source/NexusActorPools/Private/NActorPoolsDeveloperOverlay.cpp
+++ b/Plugins/ActorPools/Source/NexusActorPools/Private/NActorPoolsDeveloperOverlay.cpp
@@ -66,7 +66,7 @@ void UNActorPoolsDeveloperOverlay::NativeTick(const FGeometry& MyGeometry, float
 	Super::NativeTick(MyGeometry, InDeltaTime);
 }
 
-void UNActorPoolsDeveloperOverlay::Bind(UWorld* World)
+void UNActorPoolsDeveloperOverlay::BindWorld(UWorld* World)
 {
 	if (World == nullptr) return;
 	
@@ -94,7 +94,7 @@ void UNActorPoolsDeveloperOverlay::Bind(UWorld* World)
 	}));
 }
 
-void UNActorPoolsDeveloperOverlay::Unbind(const UWorld* World)
+void UNActorPoolsDeveloperOverlay::UnbindWorld(const UWorld* World)
 {
 	if (World == nullptr) return;
 	
@@ -128,14 +128,14 @@ void UNActorPoolsDeveloperOverlay::Unbind(const UWorld* World)
 
 void UNActorPoolsDeveloperOverlay::OnWorldPostInitialization(UWorld* World, FWorldInitializationValues WorldInitializationValues)
 {
-	Bind(World);
+	BindWorld(World);
 }
 
 void UNActorPoolsDeveloperOverlay::OnWorldBeginTearDown(UWorld* World)
 {
 	if (World != nullptr)
 	{
-		Unbind(World);
+		UnbindWorld(World);
 	}
 }
 

--- a/Plugins/ActorPools/Source/NexusActorPools/Public/NActorPoolsDeveloperOverlay.h
+++ b/Plugins/ActorPools/Source/NexusActorPools/Public/NActorPoolsDeveloperOverlay.h
@@ -23,9 +23,9 @@ class NEXUSACTORPOOLS_API UNActorPoolsDeveloperOverlay : public UNDeveloperOverl
 public:
 	
 	/** Subscribe to the actor-pool subsystem hosted by World so its pool-added events drive this overlay. */
-	virtual void Bind(UWorld* World) override;
+	virtual void BindWorld(UWorld* World) override;
 	/** Drop the subscription to the actor-pool subsystem hosted by World. */
-	virtual void Unbind(const UWorld* World) override;
+	virtual void UnbindWorld(const UWorld* World) override;
 
 	/** @return The list view widget displaying the pools. */
 	TObjectPtr<UNListView> GetActorPoolList() const { return ActorPoolList; }

--- a/Plugins/ActorPools/Source/NexusActorPools/Public/NActorPoolsDeveloperOverlay.h
+++ b/Plugins/ActorPools/Source/NexusActorPools/Public/NActorPoolsDeveloperOverlay.h
@@ -21,9 +21,9 @@ class NEXUSACTORPOOLS_API UNActorPoolsDeveloperOverlay : public UNDeveloperOverl
 	GENERATED_BODY()
 
 	/** Subscribe to the actor-pool subsystem hosted by World so its pool-added events drive this overlay. */
-	void Bind(UWorld* World);
+	virtual void Bind(UWorld* World) override;
 	/** Drop the subscription to the actor-pool subsystem hosted by World. */
-	void Unbind(const UWorld* World);
+	virtual void Unbind(const UWorld* World) override;
 
 public:
 	/** @return The list view widget displaying the pools. */

--- a/Plugins/ActorPools/Source/NexusActorPools/Public/NActorPoolsDeveloperOverlay.h
+++ b/Plugins/ActorPools/Source/NexusActorPools/Public/NActorPoolsDeveloperOverlay.h
@@ -20,12 +20,13 @@ class NEXUSACTORPOOLS_API UNActorPoolsDeveloperOverlay : public UNDeveloperOverl
 {
 	GENERATED_BODY()
 
+public:
+	
 	/** Subscribe to the actor-pool subsystem hosted by World so its pool-added events drive this overlay. */
 	virtual void Bind(UWorld* World) override;
 	/** Drop the subscription to the actor-pool subsystem hosted by World. */
 	virtual void Unbind(const UWorld* World) override;
 
-public:
 	/** @return The list view widget displaying the pools. */
 	TObjectPtr<UNListView> GetActorPoolList() const { return ActorPoolList; }
 

--- a/Plugins/DynamicRefs/Source/NexusDynamicRefs/Private/NDynamicRefsDeveloperOverlay.cpp
+++ b/Plugins/DynamicRefs/Source/NexusDynamicRefs/Private/NDynamicRefsDeveloperOverlay.cpp
@@ -28,7 +28,7 @@ void UNDynamicRefsDeveloperOverlay::NativeDestruct()
 	Super::NativeDestruct();
 }
 
-void UNDynamicRefsDeveloperOverlay::Bind(UWorld* World)
+void UNDynamicRefsDeveloperOverlay::BindWorld(UWorld* World)
 {
 	UNDynamicRefSubsystem* System = UNDynamicRefSubsystem::Get(World);
 	if (System == nullptr)
@@ -93,7 +93,7 @@ void UNDynamicRefsDeveloperOverlay::Bind(UWorld* World)
 
 
 
-void UNDynamicRefsDeveloperOverlay::Unbind(const UWorld* World)
+void UNDynamicRefsDeveloperOverlay::UnbindWorld(const UWorld* World)
 {
 	if (World == nullptr) return;
 	
@@ -142,14 +142,14 @@ void UNDynamicRefsDeveloperOverlay::Unbind(const UWorld* World)
 void UNDynamicRefsDeveloperOverlay::OnWorldPostInitialization(UWorld* World,
 	FWorldInitializationValues WorldInitializationValues)
 {
-	Bind(World);
+	BindWorld(World);
 }
 
 void UNDynamicRefsDeveloperOverlay::OnWorldBeginTearDown(UWorld* World)
 {
 	if (World != nullptr)
 	{
-		Unbind(World);
+		UnbindWorld(World);
 	}
 }
 

--- a/Plugins/DynamicRefs/Source/NexusDynamicRefs/Private/NDynamicRefsDeveloperOverlay.cpp
+++ b/Plugins/DynamicRefs/Source/NexusDynamicRefs/Private/NDynamicRefsDeveloperOverlay.cpp
@@ -13,12 +13,7 @@ void UNDynamicRefsDeveloperOverlay::NativeConstruct()
 	AddWorldDelegateHandle = FWorldDelegates::OnPostWorldInitialization.AddUObject(this, &UNDynamicRefsDeveloperOverlay::OnWorldPostInitialization);
 	RemoveWorldDelegateHandle = FWorldDelegates::OnWorldBeginTearDown.AddUObject(this, &UNDynamicRefsDeveloperOverlay::OnWorldBeginTearDown);
 	
-	// Look at all worlds and add them to bindings
-	const TIndirectArray<FWorldContext>& WorldContexts = GEngine->GetWorldContexts();
-	for (const auto& Context : WorldContexts)
-	{
-		Bind(Context.World());
-	}
+	BindAllCurrentWorlds();
 
 	Super::NativeConstruct();
 }
@@ -28,12 +23,8 @@ void UNDynamicRefsDeveloperOverlay::NativeDestruct()
 	FWorldDelegates::OnPostWorldInitialization.Remove(AddWorldDelegateHandle);
 	FWorldDelegates::OnWorldBeginTearDown.Remove(RemoveWorldDelegateHandle);
 	
-	const TIndirectArray<FWorldContext>& WorldContexts = GEngine->GetWorldContexts();
-	for (const auto& Context : WorldContexts)
-	{
-		Unbind(Context.World());
-	}
-	
+	UnbindAllCurrentWorlds();
+
 	Super::NativeDestruct();
 }
 

--- a/Plugins/DynamicRefs/Source/NexusDynamicRefs/Public/NDynamicRefsDeveloperOverlay.h
+++ b/Plugins/DynamicRefs/Source/NexusDynamicRefs/Public/NDynamicRefsDeveloperOverlay.h
@@ -22,9 +22,9 @@ class NEXUSDYNAMICREFS_API UNDynamicRefsDeveloperOverlay : public UNDeveloperOve
 	GENERATED_BODY()
 
 	/** Subscribe to the dynamic-ref subsystem hosted by World so its add/remove events drive this overlay. */
-	void Bind(UWorld* World);
+	virtual void Bind(UWorld* World) override;
 	/** Drop the subscription to the dynamic-ref subsystem hosted by World. */
-	void Unbind(const UWorld* World);
+	virtual void Unbind(const UWorld* World) override;
 
 public:
 	/** Fired when a row's button is clicked; typically used to focus/select the target object in the editor. */

--- a/Plugins/DynamicRefs/Source/NexusDynamicRefs/Public/NDynamicRefsDeveloperOverlay.h
+++ b/Plugins/DynamicRefs/Source/NexusDynamicRefs/Public/NDynamicRefsDeveloperOverlay.h
@@ -22,9 +22,9 @@ class NEXUSDYNAMICREFS_API UNDynamicRefsDeveloperOverlay : public UNDeveloperOve
 	GENERATED_BODY()
 
 	/** Subscribe to the dynamic-ref subsystem hosted by World so its add/remove events drive this overlay. */
-	virtual void Bind(UWorld* World) override;
+	virtual void BindWorld(UWorld* World) override;
 	/** Drop the subscription to the dynamic-ref subsystem hosted by World. */
-	virtual void Unbind(const UWorld* World) override;
+	virtual void UnbindWorld(const UWorld* World) override;
 
 public:
 	/** Fired when a row's button is clicked; typically used to focus/select the target object in the editor. */

--- a/Plugins/Guardian/Source/NexusGuardian/Private/NGuardianDeveloperOverlay.cpp
+++ b/Plugins/Guardian/Source/NexusGuardian/Private/NGuardianDeveloperOverlay.cpp
@@ -12,12 +12,7 @@ void UNGuardianDeveloperOverlay::NativeConstruct()
 	AddWorldDelegateHandle = FWorldDelegates::OnPostWorldInitialization.AddUObject(this, &UNGuardianDeveloperOverlay::OnWorldPostInitialization);
 	RemoveWorldDelegateHandle = FWorldDelegates::OnWorldBeginTearDown.AddUObject(this, &UNGuardianDeveloperOverlay::OnWorldBeginTearDown);
 	
-	// Look at all worlds and add them to bindings
-	const TIndirectArray<FWorldContext>& WorldContexts = GEngine->GetWorldContexts();
-	for (const auto& Context : WorldContexts)
-	{
-		Bind(Context.World());
-	}
+	BindAllCurrentWorlds();
 
 	Super::NativeConstruct();
 }
@@ -27,12 +22,8 @@ void UNGuardianDeveloperOverlay::NativeDestruct()
 	FWorldDelegates::OnPostWorldInitialization.Remove(AddWorldDelegateHandle);
 	FWorldDelegates::OnWorldBeginTearDown.Remove(RemoveWorldDelegateHandle);
 	
-	const TIndirectArray<FWorldContext>& WorldContexts = GEngine->GetWorldContexts();
-	for (const auto& Context : WorldContexts)
-	{
-		Unbind(Context.World());
-	}
-	
+	UnbindAllCurrentWorlds();
+
 	Super::NativeDestruct();
 }
 

--- a/Plugins/Guardian/Source/NexusGuardian/Private/NGuardianDeveloperOverlay.cpp
+++ b/Plugins/Guardian/Source/NexusGuardian/Private/NGuardianDeveloperOverlay.cpp
@@ -27,7 +27,7 @@ void UNGuardianDeveloperOverlay::NativeDestruct()
 	Super::NativeDestruct();
 }
 
-void UNGuardianDeveloperOverlay::Bind(UWorld* World)
+void UNGuardianDeveloperOverlay::BindWorld(UWorld* World)
 {
 	if (World->WorldType == EWorldType::PIE || World->WorldType == EWorldType::Game)
 	{
@@ -40,7 +40,7 @@ void UNGuardianDeveloperOverlay::Bind(UWorld* World)
 	UpdateBanner();
 }
 
-void UNGuardianDeveloperOverlay::Unbind(const UWorld* World)
+void UNGuardianDeveloperOverlay::UnbindWorld(const UWorld* World)
 {
 	if (World->WorldType == EWorldType::PIE || World->WorldType == EWorldType::Game)
 	{
@@ -58,7 +58,7 @@ void UNGuardianDeveloperOverlay::OnWorldPostInitialization(UWorld* World,
 {
 	if (World != nullptr)
 	{
-		Bind(World);
+		BindWorld(World);
 	}
 }
 
@@ -66,7 +66,7 @@ void UNGuardianDeveloperOverlay::OnWorldBeginTearDown(UWorld* World)
 {
 	if (World != nullptr)
 	{
-		Unbind(World);
+		UnbindWorld(World);
 	}
 }
 

--- a/Plugins/Guardian/Source/NexusGuardian/Public/NGuardianDeveloperOverlay.h
+++ b/Plugins/Guardian/Source/NexusGuardian/Public/NGuardianDeveloperOverlay.h
@@ -19,19 +19,20 @@ class NEXUSGUARDIAN_API UNGuardianDeveloperOverlay : public UNDeveloperOverlay
 {
 	GENERATED_BODY()
 
+public:
+	
+	/** Subscribe to the Guardian subsystem hosted by World so its counters feed this overlay. */
+	virtual void Bind(UWorld* World) override;
+	/** Drop the subscription to the Guardian subsystem hosted by World. */
+	virtual void Unbind(const UWorld* World) override;
+	
+protected:
 	//~UUserWidget
 	virtual void NativeConstruct() override;
 	virtual void NativeDestruct() override;
 
 	virtual void NativeTick(const FGeometry& MyGeometry, float InDeltaTime) override;
 	//End UUserWidget
-
-	/** Subscribe to the Guardian subsystem hosted by World so its counters feed this overlay. */
-	virtual void Bind(UWorld* World) override;
-	/** Drop the subscription to the Guardian subsystem hosted by World. */
-	virtual void Unbind(const UWorld* World) override;
-
-protected:
 
 	/** Container showing the object count trio (current / base / next threshold). */
 	UPROPERTY(BlueprintReadOnly,meta=(BindWidget))

--- a/Plugins/Guardian/Source/NexusGuardian/Public/NGuardianDeveloperOverlay.h
+++ b/Plugins/Guardian/Source/NexusGuardian/Public/NGuardianDeveloperOverlay.h
@@ -27,9 +27,9 @@ class NEXUSGUARDIAN_API UNGuardianDeveloperOverlay : public UNDeveloperOverlay
 	//End UUserWidget
 
 	/** Subscribe to the Guardian subsystem hosted by World so its counters feed this overlay. */
-	void Bind(UWorld* World);
+	virtual void Bind(UWorld* World) override;
 	/** Drop the subscription to the Guardian subsystem hosted by World. */
-	void Unbind(const UWorld* World);
+	virtual void Unbind(const UWorld* World) override;
 
 protected:
 

--- a/Plugins/Guardian/Source/NexusGuardian/Public/NGuardianDeveloperOverlay.h
+++ b/Plugins/Guardian/Source/NexusGuardian/Public/NGuardianDeveloperOverlay.h
@@ -22,9 +22,9 @@ class NEXUSGUARDIAN_API UNGuardianDeveloperOverlay : public UNDeveloperOverlay
 public:
 	
 	/** Subscribe to the Guardian subsystem hosted by World so its counters feed this overlay. */
-	virtual void Bind(UWorld* World) override;
+	virtual void BindWorld(UWorld* World) override;
 	/** Drop the subscription to the Guardian subsystem hosted by World. */
-	virtual void Unbind(const UWorld* World) override;
+	virtual void UnbindWorld(const UWorld* World) override;
 	
 protected:
 	//~UUserWidget

--- a/Plugins/UI/Source/NexusUI/Private/Widgets/NDeveloperOverlay.cpp
+++ b/Plugins/UI/Source/NexusUI/Private/Widgets/NDeveloperOverlay.cpp
@@ -27,7 +27,7 @@ void UNDeveloperOverlay::BindAllCurrentWorlds()
 	if (GEngine == nullptr) return;
 	for (const FWorldContext& Context : GEngine->GetWorldContexts())
 	{
-		Bind(Context.World());
+		BindWorld(Context.World());
 	}
 }
 
@@ -36,6 +36,6 @@ void UNDeveloperOverlay::UnbindAllCurrentWorlds()
 	if (GEngine == nullptr) return;
 	for (const FWorldContext& Context : GEngine->GetWorldContexts())
 	{
-		Unbind(Context.World());
+		UnbindWorld(Context.World());
 	}
 }

--- a/Plugins/UI/Source/NexusUI/Private/Widgets/NDeveloperOverlay.cpp
+++ b/Plugins/UI/Source/NexusUI/Private/Widgets/NDeveloperOverlay.cpp
@@ -21,3 +21,21 @@ void UNDeveloperOverlay::HideContainerBanner() const
 {
 	ContainerBanner->SetVisibility(ESlateVisibility::Collapsed);
 }
+
+void UNDeveloperOverlay::BindAllCurrentWorlds()
+{
+	if (GEngine == nullptr) return;
+	for (const FWorldContext& Context : GEngine->GetWorldContexts())
+	{
+		Bind(Context.World());
+	}
+}
+
+void UNDeveloperOverlay::UnbindAllCurrentWorlds()
+{
+	if (GEngine == nullptr) return;
+	for (const FWorldContext& Context : GEngine->GetWorldContexts())
+	{
+		Unbind(Context.World());
+	}
+}

--- a/Plugins/UI/Source/NexusUI/Public/Widgets/NDeveloperOverlay.h
+++ b/Plugins/UI/Source/NexusUI/Public/Widgets/NDeveloperOverlay.h
@@ -39,7 +39,16 @@ public:
 	UPROPERTY(EditDefaultsOnly)
 	bool bIsEditorUtilityWidget;
 
-protected:
+	/** Iterates all current GEngine world contexts and calls Bind() on each. Safe to call when GEngine is null. */
+	void BindAllCurrentWorlds();
+	/** Iterates all current GEngine world contexts and calls Unbind() on each. Safe to call when GEngine is null. */
+	void UnbindAllCurrentWorlds();
+
+	/** Override to subscribe to a specific world's subsystems when the overlay is constructed or a world is added. */
+	virtual void Bind(UWorld* World) {}
+	/** Override to unsubscribe from a specific world's subsystems when the overlay is destroyed or a world is removed. */
+	virtual void Unbind(const UWorld* World) {}
+
 	/** Bound UCommonBorder that provides the banner row's background brush. */
 	UPROPERTY(BlueprintReadOnly,meta=(BindWidget))
 	TObjectPtr<UCommonBorder> ContainerBanner;

--- a/Plugins/UI/Source/NexusUI/Public/Widgets/NDeveloperOverlay.h
+++ b/Plugins/UI/Source/NexusUI/Public/Widgets/NDeveloperOverlay.h
@@ -45,9 +45,9 @@ public:
 	void UnbindAllCurrentWorlds();
 
 	/** Override to subscribe to a specific world's subsystems when the overlay is constructed or a world is added. */
-	virtual void Bind(UWorld* World) {}
+	virtual void BindWorld(UWorld* World) {}
 	/** Override to unsubscribe from a specific world's subsystems when the overlay is destroyed or a world is removed. */
-	virtual void Unbind(const UWorld* World) {}
+	virtual void UnbindWorld(const UWorld* World) {}
 
 	/** Bound UCommonBorder that provides the banner row's background brush. */
 	UPROPERTY(BlueprintReadOnly,meta=(BindWidget))

--- a/Plugins/UI/Source/NexusUI/Public/Widgets/NDeveloperOverlay.h
+++ b/Plugins/UI/Source/NexusUI/Public/Widgets/NDeveloperOverlay.h
@@ -45,9 +45,15 @@ public:
 	void UnbindAllCurrentWorlds();
 
 	/** Override to subscribe to a specific world's subsystems when the overlay is constructed or a world is added. */
-	virtual void BindWorld(UWorld* World) {}
+	virtual void BindWorld(UWorld* World) 
+	{ 
+		// To be defined by overlay implementation
+	}
 	/** Override to unsubscribe from a specific world's subsystems when the overlay is destroyed or a world is removed. */
-	virtual void UnbindWorld(const UWorld* World) {}
+	virtual void UnbindWorld(const UWorld* World)
+	{ 
+		// To be defined by overlay implementation
+	}
 
 	/** Bound UCommonBorder that provides the banner row's background brush. */
 	UPROPERTY(BlueprintReadOnly,meta=(BindWidget))


### PR DESCRIPTION
## Summary

- Adds `BindAllCurrentWorlds()` and `UnbindAllCurrentWorlds()` helper methods to `UNDeveloperOverlay` (base class), each guarded against a null `GEngine`
- Promotes `Bind(UWorld*)` and `Unbind(const UWorld*)` to `virtual` in the base class (empty default bodies) so subclasses can `override` them cleanly
- Replaces the three identical `GEngine->GetWorldContexts()` for-loops in `NActorPoolsDeveloperOverlay`, `NDynamicRefsDeveloperOverlay`, and `NGuardianDeveloperOverlay` (`NativeConstruct` / `NativeDestruct`) with a single call to the shared helper

## Test plan

- [ ] Verify the three affected overlays still appear and populate correctly when a PIE session starts
- [ ] Verify they clear correctly when PIE ends
- [ ] Confirm that opening the overlay in an EUW (where `GEngine` may be set but no game world context is present) does not crash — the null guard in `BindAllCurrentWorlds` / `UnbindAllCurrentWorlds` protects this path

https://claude.ai/code/session_01UTQiq6YhBwMAToBjX4cJhA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTQiq6YhBwMAToBjX4cJhA)_